### PR TITLE
Changed the version of babel to .55 from .49. See here: https://forum…

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "lint": "eslint ."
   },
   "dependencies": {
-    "@babel/runtime": "^7.0.0-beta.49",
+    "@babel/runtime": "^7.0.0-beta.55",
     "autoprefixer": "^6.4.1",
     "babel-runtime": "^6.26.0",
     "bcrypt": "^2.0.1",


### PR DESCRIPTION
…s.meteor.com/t/solved-cannot-find-module-babel-runtime-helpers-builtin-objectspread-after-update-meteor-to-1-6-1-1/43034/18